### PR TITLE
add interaction loader

### DIFF
--- a/resources/js/loaders/LoadInteraction.ts
+++ b/resources/js/loaders/LoadInteraction.ts
@@ -1,0 +1,58 @@
+import type {LoadInteractionContract} from "./LoadInteractionContract";
+import LoadMenuInteraction from "./LoadMenuInteraction";
+import LoadLinkInteraction from "./LoadLinkInteraction";
+import Interaction from "../models/Interaction";
+
+export type LoaderType = 'menu' | 'link';
+
+type LoaderItem = {
+    type: LoaderType;
+    loader: typeof LoadMenuInteraction | typeof LoadLinkInteraction;
+};
+
+interface Prop {
+    type: string;
+}
+
+interface TInteraction extends Prop {}
+
+export default class LoadInteraction {
+    private loaders: LoaderItem[] = [];
+    private readonly interaction: TInteraction;
+
+    constructor(interaction: TInteraction) {
+        this.interaction = interaction;
+        this.registerLoaders();
+    }
+
+    public static make(type: string): LoadInteraction {
+        return new LoadInteraction(
+            new Interaction(type)
+        );
+    }
+
+    getForType(type: LoaderType) {
+        const loaderItem = this.loaders.find(item => item.type === type);
+        if (!loaderItem) {
+            return;
+        }
+
+        const {loader} = loaderItem;
+
+        // @ts-ignore
+        return new loader(this.interaction);
+    }
+
+    private registerLoaders(): void {
+        this.loaders.push(
+            {
+                type: 'menu',
+                loader: LoadMenuInteraction,
+            },
+            {
+                type: 'link',
+                loader: LoadLinkInteraction,
+            }
+        );
+    }
+}


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces a new class `LoadInteraction` that is responsible for loading different types of interactions based on the type provided. It supports loading 'menu' and 'link' interactions.
> 
> ## What changed
> A new file `LoadInteraction.ts` was added in the `resources/js/loaders` directory. This file contains the `LoadInteraction` class which has methods to register loaders and get a loader for a specific type. The class also has a static `make` method to create a new instance of `LoadInteraction`.
> 
> ## How to test
> To test this change, you can create a new instance of `LoadInteraction` and call the `getForType` method with either 'menu' or 'link' as the argument. You should get an instance of either `LoadMenuInteraction` or `LoadLinkInteraction` based on the type provided.
> 
> ## Why make this change
> This change is necessary to abstract the logic of loading different types of interactions into a separate class. This makes the code more modular and easier to maintain. It also allows for easy addition of more interaction types in the future.
</details>